### PR TITLE
Add services page

### DIFF
--- a/src/data/menu.ts
+++ b/src/data/menu.ts
@@ -3,6 +3,7 @@
 export const headerMenu = [
     { name: 'About Us', link: '/about' },
     { name: 'Our Team', link: '/team' },
+    { name: 'Services', link: '/services' },
     { name: 'Blog', link: '/blog' },
     {
         name: 'Style-Guide',

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -1,0 +1,65 @@
+import { Home, Hammer, Trees, Layers, Fence, DoorClosed } from 'lucide-astro';
+
+export interface Service {
+    id: string;
+    icon: any;
+    title: string;
+    blurb: string;
+    details: string[];
+}
+
+export const services: Service[] = [
+    {
+        id: 'new-construction',
+        icon: Home,
+        title: 'New Construction & Custom Builds',
+        blurb: 'From foundations to finished structures, we create spaces tailored to your needs.',
+        details: ['Custom Homes', 'Shops & Garages'],
+    },
+    {
+        id: 'renovations',
+        icon: Hammer,
+        title: 'Renovations & Improvements',
+        blurb: 'Interior and exterior upgrades for residential and commercial properties.',
+        details: [
+            'Interior & Exterior Renovations',
+            'Home Additions',
+            'Office & Commercial Space Renovations',
+            'Camp Maintenance & Upgrades',
+        ],
+    },
+    {
+        id: 'outdoor-living',
+        icon: Trees,
+        title: 'Outdoor Living Spaces',
+        blurb: 'Decks and patios built for relaxation and entertaining.',
+        details: ['Wood Decks', 'Composite (Maintenance-Free) Decks', 'Concrete Patios'],
+    },
+    {
+        id: 'concrete',
+        icon: Layers,
+        title: 'Concrete & Foundation Work',
+        blurb: 'Durable concrete services for driveways, sidewalks, and more.',
+        details: ['Driveways', 'Sidewalks', 'Concrete Patios'],
+    },
+    {
+        id: 'fencing',
+        icon: Fence,
+        title: 'Fencing Solutions',
+        blurb: 'Secure and attractive fencing for homes, businesses, and farms.',
+        details: ['Chain-Link Fencing (Commercial & Residential)', 'Wood Fencing', 'Farm & Ranch Fencing'],
+    },
+    {
+        id: 'doors-shutters',
+        icon: DoorClosed,
+        title: 'Doors & Security Shutters',
+        blurb: 'Overhead doors and roll shutters to protect your property.',
+        details: [
+            'Residential Garage Doors',
+            'Commercial Overhead Doors',
+            'Maintenance & Repairs on Overhead Doors',
+            'Commercial Security Roll Shutters',
+            'Roll Shutter Maintenance',
+        ],
+    },
+];

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -1,0 +1,82 @@
+---
+import Layout from '../layouts/Layout.astro';
+import InnerHero from '../components/sections/InnerHero.astro';
+import Button from '../components/ui/Button.astro';
+import { services } from '../data/services';
+import { siteConfig } from '../data/config';
+
+const heroContent = {
+    title: 'Our Services',
+    description: 'Building Quality Spaces, Enhancing Lives—Inside, Outside, and All Around.',
+};
+
+const schemaData = {
+    '@context': 'https://schema.org',
+    '@graph': services.map((s) => ({
+        '@type': 'Service',
+        name: s.title,
+        description: s.blurb,
+        serviceType: s.title,
+        provider: { '@type': 'LocalBusiness', name: siteConfig.companyName },
+        hasOfferCatalog: {
+            '@type': 'OfferCatalog',
+            name: s.title,
+            itemListElement: s.details.map((d) => ({ '@type': 'Offer', name: d })),
+        },
+    })),
+};
+---
+
+<Layout title="Our Services" description="Construction and renovation services">
+    <InnerHero content={heroContent} />
+    <nav class="bg-background-light shadow-sm">
+        <ul class="site-container mx-auto px-4 py-4 flex flex-wrap justify-center gap-4">
+            {
+                services.map((s) => (
+                    <li>
+                        <a
+                            href={`#${s.id}`}
+                            class="text-body-base hover:text-accent focus-visible:ring-2 focus-visible:ring-accent rounded px-2"
+                        >
+                            {s.title}
+                        </a>
+                    </li>
+                ))
+            }
+        </ul>
+    </nav>
+
+    <div class="site-container mx-auto px-4 py-base">
+        <h2 class="sr-only">Our Services Overview</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {
+                services.map((s) => (
+                    <section id={s.id} class="bg-white border-t-4 border-accent rounded-lg shadow-sm p-6 flex flex-col">
+                        <div class="flex items-center gap-3 mb-4">
+                            <s.icon class="text-accent w-8 h-8" aria-hidden="true" />
+                            <h3 class="text-h3 m-0" id={`${s.id}-title`}>
+                                {s.title}
+                            </h3>
+                        </div>
+                        <p class="mb-4">{s.blurb}</p>
+                        <ul class="list-disc pl-5 flex-1">
+                            {s.details.map((d) => (
+                                <li>{d}</li>
+                            ))}
+                        </ul>
+                    </section>
+                ))
+            }
+        </div>
+    </div>
+
+    <Button
+        href="/contact"
+        variant="accent"
+        class="fixed bottom-4 right-4 z-50 focus-visible:ring-accent"
+        aria-label="Get a Quote"
+    >
+        Get a Quote
+    </Button>
+    <script type="application/ld+json" set:html={JSON.stringify(schemaData)} />
+</Layout>


### PR DESCRIPTION
## Summary
- add Services page with stylized service cards
- create service data with icons and details

## Testing
- `npm run format`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685996e90558832799841b48e06d7d4c