### PR TITLE
Add rental page with trailer options

### DIFF
--- a/src/data/menu.ts
+++ b/src/data/menu.ts
@@ -4,6 +4,7 @@ export const headerMenu = [
     { name: 'About Us', link: '/about' },
     { name: 'Our Team', link: '/team' },
     { name: 'Services', link: '/services' },
+    { name: 'Rentals', link: '/rental' },
     { name: 'Blog', link: '/blog' },
     {
         name: 'Style-Guide',

--- a/src/pages/rental.astro
+++ b/src/pages/rental.astro
@@ -1,0 +1,36 @@
+---
+import Layout from '../layouts/Layout.astro';
+import InnerHero from '../components/sections/InnerHero.astro';
+import Features from '../components/sections/Features.astro';
+import { Truck, Tent } from 'lucide-astro';
+
+const heroContent = {
+    title: 'Rentals',
+    description: 'Quality equipment for your next project or getaway.',
+    backgroundImage: import('../assets/images/home/default-hero.jpg'),
+    overlayOpacity: 0.4,
+};
+
+const rentalsSection = {
+    eyebrow: 'Available Rentals',
+    title: 'Dependable Trailers Ready When You Are',
+    description: 'Choose from our heavy-duty dump trailer or comfortable holiday trailer.',
+    features: [
+        {
+            icon: Truck,
+            title: 'Dump Trailer',
+            description: 'Haul debris and materials with ease.',
+        },
+        {
+            icon: Tent,
+            title: 'Holiday Trailer',
+            description: 'Enjoy your time away with a clean and cozy trailer.',
+        },
+    ],
+};
+---
+
+<Layout title="Rentals" description="Trailer rentals for projects and vacations">
+    <InnerHero content={heroContent} />
+    <Features content={rentalsSection} background="light" padding="base" />
+</Layout>

--- a/src/pages/rental.astro
+++ b/src/pages/rental.astro
@@ -15,6 +15,11 @@ const rentalsSection = {
     eyebrow: 'Available Rentals',
     title: 'Dependable Trailers Ready When You Are',
     description: 'Choose from our heavy-duty dump trailer or comfortable holiday trailer.',
+    button: {
+        text: 'Contact Us',
+        link: '/contact',
+        variant: 'primary' as const,
+    },
     features: [
         {
             icon: Truck,
@@ -30,7 +35,16 @@ const rentalsSection = {
 };
 ---
 
-<Layout title="Rentals" description="Trailer rentals for projects and vacations">
+<Layout
+    title="Rentals"
+    description="Trailer rentals for projects and vacations"
+    footerCta={{
+        title: '',
+        description: '',
+        hideCta: true,
+        button: { text: '', link: '#' },
+    }}
+>
     <InnerHero content={heroContent} />
     <Features content={rentalsSection} background="light" padding="base" />
 </Layout>


### PR DESCRIPTION
## Summary
- create new `rental.astro` page with hero and features sections
- link Rentals in header navigation

## Testing
- `npx prettier -w src/pages/rental.astro src/data/menu.ts`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6859d4e0b6308327a32947c91382af40