### PR TITLE
Hide extraneous pages from navigation

### DIFF
--- a/src/data/menu.ts
+++ b/src/data/menu.ts
@@ -1,27 +1,19 @@
 // src/data/menu.ts
 
-export const headerMenu = [
+export interface MenuItem {
+    name: string;
+    link: string;
+    children?: { name: string; link: string }[];
+    showArrow?: boolean;
+}
+
+export const headerMenu: MenuItem[] = [
     { name: 'About Us', link: '/about' },
-    { name: 'Our Team', link: '/team' },
     { name: 'Services', link: '/services' },
     { name: 'Rentals', link: '/rental' },
-    { name: 'Blog', link: '/blog' },
-    {
-        name: 'Style-Guide',
-        link: '/style-guide',
-        showArrow: false,
-        children: [
-            { name: 'Typography', link: '/style-guide#typography' },
-            { name: 'Colors', link: '/style-guide#colors' },
-            { name: 'Links', link: '/style-guide#links' },
-            { name: 'Buttons', link: '/style-guide#buttons' },
-            { name: 'Forms', link: '/style-guide#forms' },
-            { name: 'Lists', link: '/style-guide#lists' },
-        ],
-    },
 ];
 
-export const footerMenu = [{ name: 'Style Guide', link: '/style-guide' }];
+export const footerMenu: { name: string; link: string }[] = [];
 
 export const legalMenu = [
     { name: 'Privacy Policy', link: '/legal/privacy-policy' },

--- a/src/data/menu.ts
+++ b/src/data/menu.ts
@@ -13,7 +13,11 @@ export const headerMenu: MenuItem[] = [
     { name: 'Rentals', link: '/rental' },
 ];
 
-export const footerMenu: { name: string; link: string }[] = [];
+export const footerMenu: { name: string; link: string }[] = [
+    { name: 'About Us', link: '/about' },
+    { name: 'Services', link: '/services' },
+    { name: 'Rentals', link: '/rental' },
+];
 
 export const legalMenu = [
     { name: 'Privacy Policy', link: '/legal/privacy-policy' },


### PR DESCRIPTION
## Summary
- remove Our Team, Blog, and Style-Guide links from menu
- adjust footer menu accordingly
- add explicit `MenuItem` interface so TypeScript knows about optional children

## Testing
- `npx prettier -w src/data/menu.ts`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6859d860062c8327aab85b7cc6ba7bf3